### PR TITLE
Use thread-safe deque for main thread queue

### DIFF
--- a/ETS2LA/core.py
+++ b/ETS2LA/core.py
@@ -61,9 +61,12 @@ def run():
         time.sleep(0.01) # Relieve CPU time (100fps)
         
         # Execute all main thread commands from the webserver
-        for func in webserver.mainThreadQueue:
+        while True:
+            with webserver.mainThreadQueueLock:
+                if not webserver.mainThreadQueue:
+                    break
+                func = webserver.mainThreadQueue.popleft()
             func[0](*func[1], **func[2])
-            webserver.mainThreadQueue.remove(func)
             logging.debug(f"Executed queue item: {func[0].__name__}")
         
         if variables.CLOSE:

--- a/Pages/about.py
+++ b/Pages/about.py
@@ -4,7 +4,7 @@ from ETS2LA.UI import *
 from ETS2LA import UI
 
 from ETS2LA.Utils.Game import path as game
-from ETS2LA.Networking.Servers.webserver import mainThreadQueue
+from ETS2LA.Networking.Servers.webserver import mainThreadQueue, mainThreadQueueLock
 from Modules.SDKController.main import SCSController
 from ETS2LA.Utils.translator import _, ngettext, languages, parse_language
 from ETS2LA.Utils.umami import TriggerEvent
@@ -109,7 +109,8 @@ class Page(ETS2LAPage):
             TriggerEvent("Update App")
         except Exception as e:
             logging.exception("Failed to trigger update event: %s", e)
-        mainThreadQueue.append([Update, [], {}])
+        with mainThreadQueueLock:
+            mainThreadQueue.append([Update, [], {}])
     
     def open_event(self):
         self.game_needs_update = {}
@@ -246,4 +247,4 @@ class Page(ETS2LAPage):
                         text=_("Update")
                     )
                     
-            Space(style=styles.Height("60px"))
+                Space(style=styles.Height("60px"))

--- a/Pages/updater.py
+++ b/Pages/updater.py
@@ -1,7 +1,7 @@
 from ETS2LA.UI import *
 import logging
 
-from ETS2LA.Networking.Servers.webserver import mainThreadQueue
+from ETS2LA.Networking.Servers.webserver import mainThreadQueue, mainThreadQueueLock
 from ETS2LA.Utils.version import CheckForUpdate, Update
 from ETS2LA.Utils.translator import _, ngettext
 from ETS2LA.Utils.umami import TriggerEvent
@@ -22,7 +22,8 @@ class Page(ETS2LAPage):
             TriggerEvent("Update App")
         except Exception as e:
             logging.exception("Failed to trigger update event: %s", e)
-        mainThreadQueue.append([Update, [], {}])
+        with mainThreadQueueLock:
+            mainThreadQueue.append([Update, [], {}])
         
     def open_event(self):
         self.reset_timer()


### PR DESCRIPTION
## Summary
- Replace list-based web server queue with a `deque` protected by a lock
- Pop main-thread tasks with a while loop and `popleft` for O(1) processing
- Guard queue operations across modules to ensure thread safety

## Testing
- `python -m py_compile ETS2LA/core.py ETS2LA/Networking/Servers/webserver.py Pages/about.py Pages/updater.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b08215a8b88326bae236014a940ca4